### PR TITLE
Replace obsolete fvMesh constructor macros

### DIFF
--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
@@ -85,10 +85,10 @@ Foam::dsmcCoordinateSystem::New
     Info<< "Selecting the coordinate system model:" << tab << coordSystem
         << "\n" << endl;
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(coordSystem);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(coordSystem);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -97,7 +97,7 @@ Foam::dsmcCoordinateSystem::New
         )   << "Unknown coordinate system type "
             << coordSystem << endl << endl
             << "Valid coordinate system types are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/lagrangian/dsmc/coordinateSystem/timeStepModel/basic/dsmcTimeStepModel.C
+++ b/src/lagrangian/dsmc/coordinateSystem/timeStepModel/basic/dsmcTimeStepModel.C
@@ -109,10 +109,10 @@ Foam::dsmcTimeStepModel::New
     Info<< "Selecting the time-step model:" << tab << timeStepModel
         << "\n" << endl;
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(timeStepModel);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(timeStepModel);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -120,7 +120,7 @@ Foam::dsmcTimeStepModel::New
         )   << "Unknown time-step model type "
             << timeStepModel << endl << endl
             << "Valid time-step model types are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/lagrangian/dsmc/porousMeasurements/basic/porousMeasurements.C
+++ b/src/lagrangian/dsmc/porousMeasurements/basic/porousMeasurements.C
@@ -79,10 +79,10 @@ Foam::porousMeasurements::New
     Info<< "Selecting the porous measurement model:" << tab
         << porousMeasurementModel << "\n" << endl;
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(porousMeasurementModel);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(porousMeasurementModel);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -91,7 +91,7 @@ Foam::porousMeasurements::New
         )   << "Unknown porous measurements type "
             << porousMeasurementModel << endl << endl
             << "Valid porous measurements types are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathChemistryModel/chemistryModel/basic2ChemistryModel/basic2ChemistryModelTemplates.C
+++ b/src/thermophysicalModels/strath/strathChemistryModel/chemistryModel/basic2ChemistryModel/basic2ChemistryModelTemplates.C
@@ -111,10 +111,10 @@ Foam::autoPtr<ChemistryModel> Foam::basic2ChemistryModel::New
           + word(chemistryTypeDict.lookup("chemistryThermo")) + ','
           + thermoTypeName + ">";
 
-        typename ChemistryModel::fvMeshConstructorTable::iterator cstrIter =
-            ChemistryModel::fvMeshConstructorTablePtr_->find(chemistryTypeName);
+        typename ChemistryModel::meshConstructorTable::iterator cstrIter =
+            ChemistryModel::meshConstructorTablePtr_->find(chemistryTypeName);
 
-        if (cstrIter == ChemistryModel::fvMeshConstructorTablePtr_->end())
+        if (cstrIter == ChemistryModel::meshConstructorTablePtr_->end())
         {
             FatalErrorIn(ChemistryModel::typeName + "::New(const mesh&)")
                 << "Unknown " << ChemistryModel::typeName << " type " << nl
@@ -125,7 +125,7 @@ Foam::autoPtr<ChemistryModel> Foam::basic2ChemistryModel::New
             // Get the list of all the suitable chemistry packages available
             wordList validChemistryTypeNames
             (
-                ChemistryModel::fvMeshConstructorTablePtr_->sortedToc()
+                ChemistryModel::meshConstructorTablePtr_->sortedToc()
             );
 
             // Build a table of the thermo packages constituent parts
@@ -167,16 +167,16 @@ Foam::autoPtr<ChemistryModel> Foam::basic2ChemistryModel::New
 
         Info<< "Selecting chemistry type " << chemistryTypeName << endl;
 
-        typename ChemistryModel::fvMeshConstructorTable::iterator cstrIter =
-            ChemistryModel::fvMeshConstructorTablePtr_->find(chemistryTypeName);
+        typename ChemistryModel::meshConstructorTable::iterator cstrIter =
+            ChemistryModel::meshConstructorTablePtr_->find(chemistryTypeName);
 
-        if (cstrIter == ChemistryModel::fvMeshConstructorTablePtr_->end())
+        if (cstrIter == ChemistryModel::meshConstructorTablePtr_->end())
         {
             FatalErrorIn(ChemistryModel::typeName + "::New(const mesh&)")
                 << "Unknown " << ChemistryModel::typeName << " type "
                 << chemistryTypeName << nl << nl
                 << "Valid ChemistryModel types are:" << nl
-                << ChemistryModel::fvMeshConstructorTablePtr_->sortedToc() << nl
+                << ChemistryModel::meshConstructorTablePtr_->sortedToc() << nl
                 << exit(FatalError);
         }
 

--- a/src/thermophysicalModels/strath/strathReactionThermo/basic/basic2Thermo/basic2ThermoTemplates.C
+++ b/src/thermophysicalModels/strath/strathReactionThermo/basic/basic2Thermo/basic2ThermoTemplates.C
@@ -153,11 +153,11 @@ Foam::autoPtr<Thermo> Foam::basic2Thermo::New
         )
     );
 
-    typename Thermo::fvMeshConstructorTable::iterator cstrIter =
-        lookupThermo<Thermo, typename Thermo::fvMeshConstructorTable>
+    typename Thermo::meshConstructorTable::iterator cstrIter =
+        lookupThermo<Thermo, typename Thermo::meshConstructorTable>
         (
             thermoDict,
-            Thermo::fvMeshConstructorTablePtr_
+            Thermo::meshConstructorTablePtr_
         );
 
     return autoPtr<Thermo>(cstrIter()(mesh, phaseName));

--- a/src/thermophysicalModels/strath/strathSpecie/rarefied/rarefactionParameters/rarefactionParameter/newRarefactionParameter.C
+++ b/src/thermophysicalModels/strath/strathSpecie/rarefied/rarefactionParameters/rarefactionParameter/newRarefactionParameter.C
@@ -36,12 +36,12 @@ Foam::rarefactionParameter::New
 {
     word mfpModelName = word("rarefied") +'<' + thermo.partialThermoName() + '>';
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(mfpModelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(mfpModelName);
 
     Info<< "Loading the rarefaction parameters library\n" << endl;
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -50,7 +50,7 @@ Foam::rarefactionParameter::New
         )   << "Unknown mfpModel type "
             << mfpModelName << endl << endl
             << "Valid  mfpModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelHE/newRelaxationTimeModelHE.C
+++ b/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelHE/newRelaxationTimeModelHE.C
@@ -63,10 +63,10 @@ Foam::relaxationTimeModelHE::New
             << partialHEModelName << "\n" << endl;
     }
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(HEModelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(HEModelName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -75,7 +75,7 @@ Foam::relaxationTimeModelHE::New
         )   << "Unknown HEModel type "
             << HEModelName << endl << endl
             << "Valid  HEModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelVT/newRelaxationTimeModel.C
+++ b/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelVT/newRelaxationTimeModel.C
@@ -63,10 +63,10 @@ Foam::relaxationTimeModel::New
             << endl;
     }
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(VTModelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(VTModelName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -75,7 +75,7 @@ Foam::relaxationTimeModel::New
         )   << "Unknown VTModel type "
             << VTModelName << endl << endl
             << "Valid  VTModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelVV/newRelaxationTimeModelVV.C
+++ b/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModelVV/newRelaxationTimeModelVV.C
@@ -62,10 +62,10 @@ Foam::relaxationTimeModelVV::New
             << partialVVname << "\n" << endl;
     }
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(VVModelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(VVModelName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -74,7 +74,7 @@ Foam::relaxationTimeModelVV::New
         )   << "Unknown VVModel type "
             << VVModelName << endl << endl
             << "Valid  VVModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModeleV/newRelaxationTimeModeleV.C
+++ b/src/thermophysicalModels/strath/strathSpecie/relaxationTimes/relaxationTimeModels/relaxationTimeModeleV/newRelaxationTimeModeleV.C
@@ -63,10 +63,10 @@ Foam::relaxationTimeModeleV::New
             << partialeVModelName << "\n" << endl;
     }
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(eVModelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(eVModelName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -75,7 +75,7 @@ Foam::relaxationTimeModeleV::New
         )   << "Unknown eVModel type "
             << eVModelName << endl << endl
             << "Valid  eVModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/transport/mixingRules/mixingRule/newMixingRule.C
+++ b/src/thermophysicalModels/strath/strathSpecie/transport/mixingRules/mixingRule/newMixingRule.C
@@ -53,10 +53,10 @@ Foam::mixingRule::New
     Info<< "\nLoading the transport mixing rule:" << tab 
         << partialMixingRuleName << "\n" << endl;
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(mixingRuleName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(mixingRuleName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -65,7 +65,7 @@ Foam::mixingRule::New
         )   << "Unknown mixingRuleModel type "
             << mixingRuleName << endl << endl
             << "Valid  mixingRuleModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
 

--- a/src/thermophysicalModels/strath/strathSpecie/transport/speciesDiffusion/multiSpeciesTransportModels/multiSpeciesTransportModel/newMultiSpeciesTransportModel.C
+++ b/src/thermophysicalModels/strath/strathSpecie/transport/speciesDiffusion/multiSpeciesTransportModels/multiSpeciesTransportModel/newMultiSpeciesTransportModel.C
@@ -47,10 +47,10 @@ Foam::multiSpeciesTransportModel::New
     Info<< "Loading the multispecies transport model:" << tab
         << partialModelName << "\n" << endl;
 
-    fvMeshConstructorTable::iterator cstrIter =
-        fvMeshConstructorTablePtr_->find(modelName);
+    meshConstructorTable::iterator cstrIter =
+        meshConstructorTablePtr_->find(modelName);
 
-    if (cstrIter == fvMeshConstructorTablePtr_->end())
+    if (cstrIter == meshConstructorTablePtr_->end())
     {
         FatalErrorIn
         (
@@ -59,7 +59,7 @@ Foam::multiSpeciesTransportModel::New
         )   << "Unknown diffusionModel type "
             << modelName << endl << endl
             << "Valid diffusionModels are : " << endl
-            << fvMeshConstructorTablePtr_->toc()
+            << meshConstructorTablePtr_->toc()
             << exit(FatalError);
     }
     


### PR DESCRIPTION
## Summary
- update deprecated `fvMeshConstructorTable` usages to `meshConstructorTable`
- update deprecated `fvMeshConstructorTablePtr_` usages to `meshConstructorTablePtr_`

## Testing
- `./install.sh` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_685b2c00cb448325b43662906fcbc08f